### PR TITLE
Switch to std::regex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,10 @@ target_include_directories(ImGuiColorTextEdit PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
 
 # 1-line dependency resolution
 
-find_package(boost_regex CONFIG REQUIRED)
 find_package(imgui CONFIG REQUIRED)
 
 # Link
 target_link_libraries(ImGuiColorTextEdit 
-    PUBLIC 
-        boost_regex 
+    PUBLIC
         imgui::imgui
 )

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Features I've been working on:
 - ctrl + d for selecting next match
 - ctrl + \[ and ctrl + \] for indentation
 - more language definitions for syntax highlighting
-- switched to boost regex which seems more stable
+- switched to std::regex for a lighter dependency
 - ctrl + backspace and ctrl + delete for word mode delete
 - ctrl + / for comment toggling
 - it works without setting a language definition

--- a/TextEditor.cpp
+++ b/TextEditor.cpp
@@ -1,7 +1,7 @@
 #include <algorithm>
 #include <string>
 #include <set>
-#include <boost/regex.hpp>
+#include <regex>
 
 #include "TextEditor.h"
 
@@ -12,7 +12,7 @@
 
 
 struct TextEditor::RegexList {
-    std::vector<std::pair<boost::regex, TextEditor::PaletteIndex>> mValue;
+    std::vector<std::pair<std::regex, TextEditor::PaletteIndex>> mValue;
 };
 
 
@@ -99,8 +99,8 @@ void TextEditor::SetLanguageDefinition(LanguageDefinitionId aValue)
 	}
 
     mRegexList->mValue.clear();
-	for (const auto& r : mLanguageDefinition->mTokenRegexStrings)
-        mRegexList->mValue.push_back(std::make_pair(boost::regex(r.first, boost::regex_constants::optimize), r.second));
+        for (const auto& r : mLanguageDefinition->mTokenRegexStrings)
+        mRegexList->mValue.push_back(std::make_pair(std::regex(r.first, std::regex_constants::optimize), r.second));
 
 	Colorize();
 }
@@ -2569,7 +2569,7 @@ void TextEditor::ColorizeRange(int aFromLine, int aToLine)
 		return;
 
 	std::string buffer;
-	boost::cmatch results;
+        std::cmatch results;
 	std::string id;
 
 	int endLine = std::max(0, std::min((int)mLines.size(), aToLine));
@@ -2615,8 +2615,8 @@ void TextEditor::ColorizeRange(int aFromLine, int aToLine)
 				for (const auto& p : mRegexList->mValue)
 				{
 					bool regexSearchResult = false;
-					try { regexSearchResult = boost::regex_search(first, last, results, p.first, boost::regex_constants::match_continuous); }
-					catch (...) {}
+                                        try { regexSearchResult = std::regex_search(first, last, results, p.first, std::regex_constants::match_continuous); }
+                                        catch (const std::regex_error&) {}
 					if (regexSearchResult)
 					{
 						hasTokenizeResult = true;


### PR DESCRIPTION
## Summary
- drop Boost.Regex requirement
- use std::regex throughout `TextEditor`
- update README to mention std::regex instead of Boost

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "imgui")*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_685e7228709c83299e6491f162d6c120