### PR TITLE
Fix windows size conversion warnings

### DIFF
--- a/TextEditor.h
+++ b/TextEditor.h
@@ -1,36 +1,47 @@
 #pragma once
 
-#include <cmath>
-#include <cassert>
-#include <iostream>
-#include <string>
-#include <vector>
-#include <array>
-#include <memory>
-#include <unordered_set>
-#include <unordered_map>
-#include <map>
 #include "imgui.h"
+#include <array>
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
-class IMGUI_API TextEditor
-{
-public:
+class IMGUI_API TextEditor {
+  public:
 	// ------------- Exposed API ------------- //
 
 	TextEditor();
 	~TextEditor();
 
-	enum class PaletteId
-	{
-		Dark, Light, Mariana, RetroBlue
+	enum class PaletteId {
+		Dark,
+		Light,
+		Mariana,
+		RetroBlue
 	};
-	enum class LanguageDefinitionId
-	{
-		None, Cpp, C, Cs, Python, Lua, Json, Sql, AngelScript, Glsl, Hlsl
+	enum class LanguageDefinitionId {
+		None,
+		Cpp,
+		C,
+		Cs,
+		Python,
+		Lua,
+		Json,
+		Sql,
+		AngelScript,
+		Glsl,
+		Hlsl
 	};
-	enum class SetViewAtLineMode
-	{
-		FirstVisibleLine, Centered, LastVisibleLine
+	enum class SetViewAtLineMode {
+		FirstVisibleLine,
+		Centered,
+		LastVisibleLine
 	};
 
 	inline void SetReadOnlyEnabled(bool aValue) { mReadOnly = aValue; }
@@ -43,16 +54,16 @@ public:
 	inline bool IsShowLineNumbersEnabled() const { return mShowLineNumbers; }
 	inline void SetShortTabsEnabled(bool aValue) { mShortTabs = aValue; }
 	inline bool IsShortTabsEnabled() const { return mShortTabs; }
-	inline int GetLineCount() const { return mLines.size(); }
+	inline int GetLineCount() const { return static_cast<int>(mLines.size()); }
 	void SetPalette(PaletteId aValue);
 	PaletteId GetPalette() const { return mPaletteId; }
 	void SetLanguageDefinition(LanguageDefinitionId aValue);
 	LanguageDefinitionId GetLanguageDefinition() const { return mLanguageDefinitionId; };
-	const char* GetLanguageDefinitionName() const;
+	const char *GetLanguageDefinitionName() const;
 	void SetTabSize(int aValue);
 	inline int GetTabSize() const { return mTabSize; }
 	void SetLineSpacing(float aValue);
-	inline float GetLineSpacing() const { return mLineSpacing;  }
+	inline float GetLineSpacing() const { return mLineSpacing; }
 
 	inline static void SetDefaultPalette(PaletteId aValue) { defaultPalette = aValue; }
 	inline static PaletteId GetDefaultPalette() { return defaultPalette; }
@@ -60,15 +71,14 @@ public:
 	void SelectAll();
 	void SelectLine(int aLine);
 	void SelectRegion(int aStartLine, int aStartChar, int aEndLine, int aEndChar);
-	void SelectNextOccurrenceOf(const char* aText, int aTextSize, bool aCaseSensitive = true);
-	void SelectAllOccurrencesOf(const char* aText, int aTextSize, bool aCaseSensitive = true);
+	void SelectNextOccurrenceOf(const char *aText, int aTextSize, bool aCaseSensitive = true);
+	void SelectAllOccurrencesOf(const char *aText, int aTextSize, bool aCaseSensitive = true);
 	bool AnyCursorHasSelection() const;
 	bool AllCursorsHaveSelection() const;
 	void ClearExtraCursors();
 	void ClearSelections();
 	void SetCursorPosition(int aLine, int aCharIndex);
-	inline void GetCursorPosition(int& outLine, int& outColumn) const
-	{
+	inline void GetCursorPosition(int &outLine, int &outColumn) const {
 		auto coords = GetSanitizedCursorCoordinates();
 		outLine = coords.mLine;
 		outColumn = coords.mColumn;
@@ -86,48 +96,44 @@ public:
 	inline bool CanRedo() const { return !mReadOnly && mUndoIndex < (int)mUndoBuffer.size(); };
 	inline int GetUndoIndex() const { return mUndoIndex; };
 
-	void SetText(const std::string& aText);
+	void SetText(const std::string &aText);
 	std::string GetText() const;
 
-	void SetTextLines(const std::vector<std::string>& aLines);
+	void SetTextLines(const std::vector<std::string> &aLines);
 	std::vector<std::string> GetTextLines() const;
 
-	bool Render(const char* aTitle, bool aParentIsFocused = false, const ImVec2& aSize = ImVec2(), bool aBorder = false);
+	bool Render(const char *aTitle, bool aParentIsFocused = false, const ImVec2 &aSize = ImVec2(), bool aBorder = false);
 
-	void ImGuiDebugPanel(const std::string& panelName = "Debug");
+	void ImGuiDebugPanel(const std::string &panelName = "Debug");
 	void UnitTests();
 
-private:
+  private:
 	// ------------- Generic utils ------------- //
 
-	static inline ImVec4 U32ColorToVec4(ImU32 in)
-	{
+	static inline ImVec4 U32ColorToVec4(ImU32 in) {
 		float s = 1.0f / 255.0f;
 		return ImVec4(
-			((in >> IM_COL32_A_SHIFT) & 0xFF) * s,
-			((in >> IM_COL32_B_SHIFT) & 0xFF) * s,
-			((in >> IM_COL32_G_SHIFT) & 0xFF) * s,
-			((in >> IM_COL32_R_SHIFT) & 0xFF) * s);
+		    ((in >> IM_COL32_A_SHIFT) & 0xFF) * s,
+		    ((in >> IM_COL32_B_SHIFT) & 0xFF) * s,
+		    ((in >> IM_COL32_G_SHIFT) & 0xFF) * s,
+		    ((in >> IM_COL32_R_SHIFT) & 0xFF) * s);
 	}
-	static inline bool IsUTFSequence(char c)
-	{
+	static inline bool IsUTFSequence(char c) {
 		return (c & 0xC0) == 0x80;
 	}
-	static inline float Distance(const ImVec2& a, const ImVec2& b)
-	{
+	static inline float Distance(const ImVec2 &a, const ImVec2 &b) {
 		float x = a.x - b.x;
 		float y = a.y - b.y;
 		return sqrt(x * x + y * y);
 	}
-	template<typename T>
+	template <typename T>
 	static inline T Max(T a, T b) { return a > b ? a : b; }
-	template<typename T>
+	template <typename T>
 	static inline T Min(T a, T b) { return a < b ? a : b; }
 
 	// ------------- Internal ------------- //
 
-	enum class PaletteIndex
-	{
+	enum class PaletteIndex {
 		Default,
 		Keyword,
 		Number,
@@ -160,74 +166,64 @@ private:
 	// how many space is necessary to reach the next tab stop.
 	// For example, coordinate (1, 5) represents the character 'B' in a line "\tABC", when mTabSize = 4,
 	// because it is rendered as "    ABC" on the screen.
-	struct Coordinates
-	{
+	struct Coordinates {
 		int mLine, mColumn;
 		Coordinates() : mLine(0), mColumn(0) {}
-		Coordinates(int aLine, int aColumn) : mLine(aLine), mColumn(aColumn)
-		{
+		Coordinates(int aLine, int aColumn) : mLine(aLine), mColumn(aColumn) {
 			assert(aLine >= 0);
 			assert(aColumn >= 0);
 		}
-		static Coordinates Invalid() { static Coordinates invalid(-1, -1); return invalid; }
-
-		bool operator ==(const Coordinates& o) const
-		{
-			return
-				mLine == o.mLine &&
-				mColumn == o.mColumn;
+		static Coordinates Invalid() {
+			static Coordinates invalid(-1, -1);
+			return invalid;
 		}
 
-		bool operator !=(const Coordinates& o) const
-		{
-			return
-				mLine != o.mLine ||
-				mColumn != o.mColumn;
+		bool operator==(const Coordinates &o) const {
+			return mLine == o.mLine &&
+			       mColumn == o.mColumn;
 		}
 
-		bool operator <(const Coordinates& o) const
-		{
+		bool operator!=(const Coordinates &o) const {
+			return mLine != o.mLine ||
+			       mColumn != o.mColumn;
+		}
+
+		bool operator<(const Coordinates &o) const {
 			if (mLine != o.mLine)
 				return mLine < o.mLine;
 			return mColumn < o.mColumn;
 		}
 
-		bool operator >(const Coordinates& o) const
-		{
+		bool operator>(const Coordinates &o) const {
 			if (mLine != o.mLine)
 				return mLine > o.mLine;
 			return mColumn > o.mColumn;
 		}
 
-		bool operator <=(const Coordinates& o) const
-		{
+		bool operator<=(const Coordinates &o) const {
 			if (mLine != o.mLine)
 				return mLine < o.mLine;
 			return mColumn <= o.mColumn;
 		}
 
-		bool operator >=(const Coordinates& o) const
-		{
+		bool operator>=(const Coordinates &o) const {
 			if (mLine != o.mLine)
 				return mLine > o.mLine;
 			return mColumn >= o.mColumn;
 		}
 
-		Coordinates operator -(const Coordinates& o)
-		{
+		Coordinates operator-(const Coordinates &o) {
 			return Coordinates(mLine - o.mLine, mColumn - o.mColumn);
 		}
 
-		Coordinates operator +(const Coordinates& o)
-		{
+		Coordinates operator+(const Coordinates &o) {
 			return Coordinates(mLine + o.mLine, mColumn + o.mColumn);
 		}
 	};
 
-	struct Cursor
-	{
-		Coordinates mInteractiveStart = { 0, 0 };
-		Coordinates mInteractiveEnd = { 0, 0 };
+	struct Cursor {
+		Coordinates mInteractiveStart = {0, 0};
+		Coordinates mInteractiveEnd = {0, 0};
 		inline Coordinates GetSelectionStart() const { return mInteractiveStart < mInteractiveEnd ? mInteractiveStart : mInteractiveEnd; }
 		inline Coordinates GetSelectionEnd() const { return mInteractiveStart > mInteractiveEnd ? mInteractiveStart : mInteractiveEnd; }
 		inline bool HasSelection() const { return mInteractiveStart != mInteractiveEnd; }
@@ -237,14 +233,13 @@ private:
 	{
 		int mCurrentCursor = 0;
 		int mLastAddedCursor = 0;
-		std::vector<Cursor> mCursors = { {{0,0}} };
+		std::vector<Cursor> mCursors = {{{0, 0}}};
 		void AddCursor();
 		int GetLastAddedCursorIndex();
 		void SortCursorsFromTopToBottom();
 	};
 
-	struct Identifier
-	{
+	struct Identifier {
 		Coordinates mLocation;
 		std::string mDeclaration;
 	};
@@ -252,8 +247,7 @@ private:
 	typedef std::unordered_map<std::string, Identifier> Identifiers;
 	typedef std::array<ImU32, (unsigned)PaletteIndex::Max> Palette;
 
-	struct Glyph
-	{
+	struct Glyph {
 		char mChar;
 		PaletteIndex mColorIndex = PaletteIndex::Default;
 		bool mComment : 1;
@@ -261,15 +255,14 @@ private:
 		bool mPreprocessor : 1;
 
 		Glyph(char aChar, PaletteIndex aColorIndex) : mChar(aChar), mColorIndex(aColorIndex),
-			mComment(false), mMultiLineComment(false), mPreprocessor(false) {}
+		                                              mComment(false), mMultiLineComment(false), mPreprocessor(false) {}
 	};
 
 	typedef std::vector<Glyph> Line;
 
-	struct LanguageDefinition
-	{
+	struct LanguageDefinition {
 		typedef std::pair<std::string, PaletteIndex> TokenRegexString;
-		typedef bool(*TokenizeCallback)(const char* in_begin, const char* in_end, const char*& out_begin, const char*& out_end, PaletteIndex& paletteIndex);
+		typedef bool (*TokenizeCallback)(const char *in_begin, const char *in_end, const char *&out_begin, const char *&out_end, PaletteIndex &paletteIndex);
 
 		std::string mName;
 		std::unordered_set<std::string> mKeywords;
@@ -281,41 +274,39 @@ private:
 		std::vector<TokenRegexString> mTokenRegexStrings;
 		bool mCaseSensitive = true;
 
-		static const LanguageDefinition& Cpp();
-		static const LanguageDefinition& Hlsl();
-		static const LanguageDefinition& Glsl();
-		static const LanguageDefinition& Python();
-		static const LanguageDefinition& C();
-		static const LanguageDefinition& Sql();
-		static const LanguageDefinition& AngelScript();
-		static const LanguageDefinition& Lua();
-		static const LanguageDefinition& Cs();
-		static const LanguageDefinition& Json();
+		static const LanguageDefinition &Cpp();
+		static const LanguageDefinition &Hlsl();
+		static const LanguageDefinition &Glsl();
+		static const LanguageDefinition &Python();
+		static const LanguageDefinition &C();
+		static const LanguageDefinition &Sql();
+		static const LanguageDefinition &AngelScript();
+		static const LanguageDefinition &Lua();
+		static const LanguageDefinition &Cs();
+		static const LanguageDefinition &Json();
 	};
 
-	enum class UndoOperationType { Add, Delete };
-	struct UndoOperation
-	{
+	enum class UndoOperationType { Add,
+		                           Delete };
+	struct UndoOperation {
 		std::string mText;
 		TextEditor::Coordinates mStart;
 		TextEditor::Coordinates mEnd;
 		UndoOperationType mType;
 	};
 
-
-	class UndoRecord
-	{
-	public:
+	class UndoRecord {
+	  public:
 		UndoRecord() {}
 		~UndoRecord() {}
 
 		UndoRecord(
-			const std::vector<UndoOperation>& aOperations,
-			TextEditor::EditorState& aBefore,
-			TextEditor::EditorState& aAfter);
+		    const std::vector<UndoOperation> &aOperations,
+		    TextEditor::EditorState &aBefore,
+		    TextEditor::EditorState &aAfter);
 
-		void Undo(TextEditor* aEditor);
-		void Redo(TextEditor* aEditor);
+		void Undo(TextEditor *aEditor);
+		void Redo(TextEditor *aEditor);
 
 		std::vector<UndoOperation> mOperations;
 
@@ -323,19 +314,22 @@ private:
 		EditorState mAfter;
 	};
 
-	std::string GetText(const Coordinates& aStart, const Coordinates& aEnd) const;
+	std::string GetText(const Coordinates &aStart, const Coordinates &aEnd) const;
 	std::string GetClipboardText() const;
 	std::string GetSelectedText(int aCursor = -1) const;
 
-	void SetCursorPosition(const Coordinates& aPosition, int aCursor = -1, bool aClearSelection = true);
+	void SetCursorPosition(const Coordinates &aPosition, int aCursor = -1, bool aClearSelection = true);
 
-	int InsertTextAt(Coordinates& aWhere, const char* aValue);
-	void InsertTextAtCursor(const char* aValue, int aCursor = -1);
+	int InsertTextAt(Coordinates &aWhere, const char *aValue);
+	void InsertTextAtCursor(const char *aValue, int aCursor = -1);
 
-	enum class MoveDirection { Right = 0, Left = 1, Up = 2, Down = 3 };
-	bool Move(int& aLine, int& aCharIndex, bool aLeft = false, bool aLockLine = false) const;
-	void MoveCharIndexAndColumn(int aLine, int& aCharIndex, int& aColumn) const;
-	void MoveCoords(Coordinates& aCoords, MoveDirection aDirection, bool aWordMode = false, int aLineCount = 1) const;
+	enum class MoveDirection { Right = 0,
+		                       Left = 1,
+		                       Up = 2,
+		                       Down = 3 };
+	bool Move(int &aLine, int &aCharIndex, bool aLeft = false, bool aLockLine = false) const;
+	void MoveCharIndexAndColumn(int aLine, int &aCharIndex, int &aColumn) const;
+	void MoveCoords(Coordinates &aCoords, MoveDirection aDirection, bool aWordMode = false, int aLineCount = 1) const;
 
 	void MoveUp(int aAmount = 1, bool aSelect = false);
 	void MoveDown(int aAmount = 1, bool aSelect = false);
@@ -347,45 +341,45 @@ private:
 	void MoveEnd(bool aSelect = false);
 	void EnterCharacter(ImWchar aChar, bool aShift);
 	void Backspace(bool aWordMode = false);
-	void Delete(bool aWordMode = false, const EditorState* aEditorState = nullptr);
+	void Delete(bool aWordMode = false, const EditorState *aEditorState = nullptr);
 
 	void SetSelection(Coordinates aStart, Coordinates aEnd, int aCursor = -1);
 	void SetSelection(int aStartLine, int aStartChar, int aEndLine, int aEndChar, int aCursor = -1);
 
-	void SelectNextOccurrenceOf(const char* aText, int aTextSize, int aCursor = -1, bool aCaseSensitive = true);
+	void SelectNextOccurrenceOf(const char *aText, int aTextSize, int aCursor = -1, bool aCaseSensitive = true);
 	void AddCursorForNextOccurrence(bool aCaseSensitive = true);
-	bool FindNextOccurrence(const char* aText, int aTextSize, const Coordinates& aFrom, Coordinates& outStart, Coordinates& outEnd, bool aCaseSensitive = true);
-	bool FindMatchingBracket(int aLine, int aCharIndex, Coordinates& out);
+	bool FindNextOccurrence(const char *aText, int aTextSize, const Coordinates &aFrom, Coordinates &outStart, Coordinates &outEnd, bool aCaseSensitive = true);
+	bool FindMatchingBracket(int aLine, int aCharIndex, Coordinates &out);
 	void ChangeCurrentLinesIndentation(bool aIncrease);
 	void MoveUpCurrentLines();
 	void MoveDownCurrentLines();
 	void ToggleLineComment();
 	void RemoveCurrentLines();
 
-	float TextDistanceToLineStart(const Coordinates& aFrom, bool aSanitizeCoords = true) const;
+	float TextDistanceToLineStart(const Coordinates &aFrom, bool aSanitizeCoords = true) const;
 	void EnsureCursorVisible(int aCursor = -1, bool aStartToo = false);
 
-	Coordinates SanitizeCoordinates(const Coordinates& aValue) const;
+	Coordinates SanitizeCoordinates(const Coordinates &aValue) const;
 	Coordinates GetSanitizedCursorCoordinates(int aCursor = -1, bool aStart = false) const;
-	Coordinates ScreenPosToCoordinates(const ImVec2& aPosition, bool* isOverLineNumber = nullptr) const;
-	Coordinates FindWordStart(const Coordinates& aFrom) const;
-	Coordinates FindWordEnd(const Coordinates& aFrom) const;
-	int GetCharacterIndexL(const Coordinates& aCoordinates) const;
-	int GetCharacterIndexR(const Coordinates& aCoordinates) const;
+	Coordinates ScreenPosToCoordinates(const ImVec2 &aPosition, bool *isOverLineNumber = nullptr) const;
+	Coordinates FindWordStart(const Coordinates &aFrom) const;
+	Coordinates FindWordEnd(const Coordinates &aFrom) const;
+	int GetCharacterIndexL(const Coordinates &aCoordinates) const;
+	int GetCharacterIndexR(const Coordinates &aCoordinates) const;
 	int GetCharacterColumn(int aLine, int aIndex) const;
 	int GetFirstVisibleCharacterIndex(int aLine) const;
 	int GetLineMaxColumn(int aLine, int aLimit = -1) const;
 
-	Line& InsertLine(int aIndex);
-	void RemoveLine(int aIndex, const std::unordered_set<int>* aHandledCursors = nullptr);
+	Line &InsertLine(int aIndex);
+	void RemoveLine(int aIndex, const std::unordered_set<int> *aHandledCursors = nullptr);
 	void RemoveLines(int aStart, int aEnd);
-	void DeleteRange(const Coordinates& aStart, const Coordinates& aEnd);
+	void DeleteRange(const Coordinates &aStart, const Coordinates &aEnd);
 	void DeleteSelection(int aCursor = -1);
 
 	void RemoveGlyphsFromLine(int aLine, int aStartChar, int aEndChar = -1);
 	void AddGlyphsToLine(int aLine, int aTargetIndex, Line::iterator aSourceStart, Line::iterator aSourceEnd);
 	void AddGlyphToLine(int aLine, int aTargetIndex, Glyph aGlyph);
-	ImU32 GetGlyphColor(const Glyph& aGlyph) const;
+	ImU32 GetGlyphColor(const Glyph &aGlyph) const;
 
 	void HandleKeyboardInputs(bool aParentIsFocused = false);
 	void HandleMouseInputs();
@@ -396,7 +390,7 @@ private:
 	void OnLineChanged(bool aBeforeChange, int aLine, int aColumn, int aCharCount, bool aDeleted);
 	void MergeCursorsIfPossible();
 
-	void AddUndo(UndoRecord& aValue);
+	void AddUndo(UndoRecord &aValue);
 
 	void Colorize(int aFromLine = 0, int aCount = -1);
 	void ColorizeRange(int aFromLine = 0, int aToLine = 0);
@@ -451,21 +445,21 @@ private:
 	PaletteId mPaletteId;
 	Palette mPalette;
 	LanguageDefinitionId mLanguageDefinitionId;
-	const LanguageDefinition* mLanguageDefinition = nullptr;
+	const LanguageDefinition *mLanguageDefinition = nullptr;
 
 	inline bool IsHorizontalScrollbarVisible() const { return mCurrentSpaceWidth > mContentWidth; }
 	inline bool IsVerticalScrollbarVisible() const { return mCurrentSpaceHeight > mContentHeight; }
 	inline int TabSizeAtColumn(int aColumn) const { return mTabSize - (aColumn % mTabSize); }
 
-	static const Palette& GetDarkPalette();
-	static const Palette& GetMarianaPalette();
-	static const Palette& GetLightPalette();
-	static const Palette& GetRetroBluePalette();
+	static const Palette &GetDarkPalette();
+	static const Palette &GetMarianaPalette();
+	static const Palette &GetLightPalette();
+	static const Palette &GetRetroBluePalette();
 	static const std::unordered_map<char, char> OPEN_TO_CLOSE_CHAR;
 	static const std::unordered_map<char, char> CLOSE_TO_OPEN_CHAR;
 	static PaletteId defaultPalette;
 
-private:
-    struct RegexList;
-    std::shared_ptr<RegexList> mRegexList;
+  private:
+	struct RegexList;
+	std::shared_ptr<RegexList> mRegexList;
 };


### PR DESCRIPTION
## Summary
- fix integer and float conversions that triggered MSVC warnings
- format TextEditor.cpp and TextEditor.h

## Testing
- `cmake -S . -B build` *(fails: Could not find imgui)*

------
https://chatgpt.com/codex/tasks/task_e_685ea05e15c0832999f358ba2f2af1ee